### PR TITLE
Bugfixes, doc fixes, and feature additions

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,8 +1,17 @@
+DiscordDisconnect	vimsence.txt	/*DiscordDisconnect*
+DiscordReconnect	vimsence.txt	/*DiscordReconnect*
+DiscordUpdatePresence	vimsence.txt	/*DiscordUpdatePresence*
+UpdatePresence	vimsence.txt	/*UpdatePresence*
 VimSenceBugs	vimsence.txt	/*VimSenceBugs*
 VimSenceContributing	vimsence.txt	/*VimSenceContributing*
+VimSenceFlatpak	vimsence.txt	/*VimSenceFlatpak*
+VimSenceIgnore	vimsence.txt	/*VimSenceIgnore*
 VimSenceIntroduction	vimsence.txt	/*VimSenceIntroduction*
 VimSenceLicense	vimsence.txt	/*VimSenceLicense*
 VimSenceUsage	vimsence.txt	/*VimSenceUsage*
 Vimsence-contents	vimsence.txt	/*Vimsence-contents*
 VimsenceChangelog	vimsence.txt	/*VimsenceChangelog*
+g:vimsence_discord_flatpak	vimsence.txt	/*g:vimsence_discord_flatpak*
+g:vimsence_ignored_directories	vimsence.txt	/*g:vimsence_ignored_directories*
+g:vimsence_ignored_filetypes	vimsence.txt	/*g:vimsence_ignored_filetypes*
 vimsence.txt	vimsence.txt	/*vimsence.txt*

--- a/doc/vimsence.txt
+++ b/doc/vimsence.txt
@@ -11,13 +11,18 @@ CONTENTS                                                   *Vimsence-contents*
 
     1. Introduction .................................. |VimSenceIntroduction|
     2. Usage ......................................... |VimSenceUsage|
+        Manually updating your presence .............. |DiscordUpdatePresence|
+        Reconnecting to Discord ...................... |DiscordReconnect|
+        Disconnecting from Discord ................... |DiscordDisconnect|
+        Ignoring file types or folders ............... |VimSenceIgnore|
+        Flatpak support (Linux) ...................... |VimSenceFlatpak|
     3. License ....................................... |VimSenceLisence|
     4. Bugs .......................................... |VimSenceBugs|
     5. Contributing .................................. |VimSenceContributing|
     6. Contributing .................................. |VimSenceChangelog|
 
 ==============================================================================
-1. Introduction                                          *VimSenceIntroduction*
+1. Introduction                                         *VimSenceIntroduction*
 
 VimSence updates the Discord "now playing" status with what you're currently
 editing in Vim. This way you can show all your friends how cool you are
@@ -29,32 +34,94 @@ programming in Vim.
 You just need to have this plugin installed and Discord running, the rest
 will work automatically.
 
-If you have to manually update your presence for some kind of reason, you
-can use this:
+There are still some commands, and some config options that can be set.
+
+------------------------------------------------------------------------------
+                                      *DiscordUpdatePresence* *UpdatePresence*
+Manually updating your presence ~
+
+If you have to manually update your presence, you can use this:
 >
-    :UpdatePresence
+    :DiscordUpdatePresence
 <
 This will force update the Discord presence with what you're currently
 editing.
 
-Manually reconnecting, either because Discord wasn't running or something
-else forced the connection to be closed, can be done with:
+------------------------------------------------------------------------------
+                                                            *DiscordReconnect*
+Reconnecting to Discord ~
+
+Manually reconnecting to Discord can be done with this command:
 >
     :DiscordReconnect
 <
-This will also attempt to close an existing session, if one exists.
+This will also attempt to close an existing session, if one exists. This also
+refreshes your presence. The purpose of this command is avoiding the need to
+reboot Vim because the Discord presence socket was disconnected, which can
+happen under various circumstances.
 
-Additionally, both file types and directories can be ignored, which means
-they won't be displayed on Discord. Note that the file type variant uses
-file types, not file extensions. 
-The variable names used are:
+------------------------------------------------------------------------------
+                                                           *DiscordDisconnect*
+Disconnecting from Discord ~
 
-> 
-    g:vimsence_ignored_directories
-    g:vimsence_ignored_file_types 
+It's also possible to manually disconnect, which effectively disables the
+plugin and prevents your status from showing up. This command can be used for
+that:
+>
+    :DiscordDisconnect
 <
 
-These are expected to be arrays of strings. By default, these do not exclude any folders or file types.
+------------------------------------------------------------------------------
+               *g:vimsence_ignored_directories* *g:vimsence_ignored_filetypes*
+                                                              *VimSenceIgnore*
+Ignoring directories or file types ~
+
+Both file types and directories can be ignored, which means they won't be
+displayed on Discord. Note that the file type variant uses file types, not
+file extensions. See `:echo &filetype` for the filetype of the current buffer.
+The variable names used are:
+>
+    g:vimsence_ignored_directories
+    g:vimsence_ignored_file_types
+<
+These are expected to be arrays of strings. By default, these do not exclude
+any folders or file types.
+
+------------------------------------------------------------------------------
+                                                  *g:vimsence_discord_flatpak*
+                                                             *VimSenceFlatpak*
+Support for Flatpak ~
+
+(Note: This only applies to Linux, and specifically distros Flatpak supports.
+ Having the option enabled on Linux without running the flatpak version will
+ cause the connection to fail)
+
+Flatpak support can be enabled with:
+>
+    let g:vimsence_discord_flatpak=1
+>
+Discord's Flatpak package exports its socket differently. Without
+`let g:vimsence_discord_flatpak=1`, vimsence will try to connect to the
+location the non-flatpak version exports its socket. This is typically
+`$XDG_RUNTIME_DIR`. The Flatpak version of Discord is forced to export the RPC
+socket under `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/` because of how the
+sandboxing works. Unfortunately, this breaks vimsence, because the socket is
+set up in a different location than expected.
+
+A typical way to work around this is by symlinking the socket where it
+normally would be, but since the directory is deleted and regenerated on
+login/logout, it becomes inefficient.
+
+This is where `g:vimsence_discord_flatpak` comes in. With the option enabled,
+vimsence will connect to the socket by looking for the socket where the Flatpak
+version exports it. This is covered in slightly more detail on Discord's flatpak
+wiki:
+https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)
+
+The option also makes it possible to bypass symlinking entirely.
+
+TL;DR: `let g:vimsence_discord_flatpak=1` to fix issues with Flatpak and
+Discord's RPC socket
 
 ==============================================================================
 3. License                                                   *VimSenceLicense*
@@ -65,7 +132,7 @@ VimSense is licensed under the MIT license.
 4. Bugs                                                         *VimSenceBugs*
 
 If you find a bug please post it on the issue tracker:
-http://github.com/ananagame/vimsence/issues/
+https://github.com/hugolgst/vimsence/issues
 
 ==============================================================================
 5. Contributing                                         *VimSenceContributing*
@@ -73,10 +140,12 @@ http://github.com/ananagame/vimsence/issues/
 Think you can make this plugin better? Awesome! Fork it on GitHub and send a
 pull request.
 
-GitHub: http://github.com/ananagame/vimsence/
+GitHub: https://github.com/hugolgst/vimsence
 
 ==============================================================================
 6. Changelog                                               *VimsenceChangelog*
 
 v1.0.0
     * Initial stable release.
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/vimsence.vim
+++ b/plugin/vimsence.vim
@@ -7,6 +7,12 @@ if exists('g:vimsence_loaded')
     finish
 endif
 
+if !exists('g:vimsence_discord_flatpak')
+    " Flatpak support is disabled by default.
+    " This has no effect on Windows.
+    let g:vimsence_discord_flatpak=0
+endif
+
 let s:plugin_root_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 
 python3 << EOF
@@ -16,10 +22,11 @@ import vim
 plugin_root_dir = vim.eval('s:plugin_root_dir')
 python_root_dir = normpath(join(plugin_root_dir, '..', 'python'))
 sys.path.insert(0, python_root_dir)
+
 import vimsence
 EOF
 
-function! UpdatePresence()
+function! DiscordUpdatePresence()
     python3 vimsence.update_presence()
 endfunction
 
@@ -27,12 +34,18 @@ function! DiscordReconnect()
     python3 vimsence.reconnect()
 endfunction
 
-command! -nargs=0 UpdatePresence call UpdatePresence()
+function! DiscordDisconnect()
+    python3 vimsence.disconnect()
+endfunction
+
+command! -nargs=0 UpdatePresence echo "This command has been deprecated. Use :DiscordUpdatePresence instead."
+command! -nargs=0 DiscordUpdatePresence call DiscordUpdatePresence()
 command! -nargs=0 DiscordReconnect call DiscordReconnect()
+command! -nargs=0 DiscordDisconnect call DiscordDisconnect()
 
 augroup DiscordPresence
     autocmd!
-    autocmd BufNewFile,BufRead,BufEnter * :call UpdatePresence()
+    autocmd BufNewFile,BufRead,BufEnter * :call DiscordUpdatePresence()
 augroup END
 
 let g:vimsence_loaded = 1

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -23,7 +23,7 @@ has_thumbnail = [
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'ikea'
 ]
 # Remaps file types to specific icons.
-remap = { 
+remap = {
         "python": "py", "markdown": "md", "ruby": "rb", "rust": "rs", "typescript": "ts",
         "javascript": "js"
 }
@@ -49,6 +49,9 @@ except Exception as e:
 def update_presence():
     """Update presence in Discord
     """
+    if not rpc_obj.connected:
+        # If we're flagged as disconnected, skip all this processing and save some CPU cycles.
+        return;
     global ignored_file_types
     global ignored_directories
     if (ignored_file_types == -1):
@@ -75,7 +78,7 @@ def update_presence():
 
     if (u.contains(ignored_file_types, filetype) or u.contains(ignored_directories, directory)):
         # Priority #1: if the file type or folder is ignored, use the default activity to avoid exposing
-        # the folder or file. 
+        # the folder or file.
         rpc_obj.set_activity(base_activity)
         return
     elif filetype and filetype in has_thumbnail:
@@ -95,7 +98,7 @@ def update_presence():
         details = 'Searching for files'
         state = 'Workspace: {}'.format(directory)
     elif (is_writeable() and filename):
-        # if none of the other match, check if the buffer is writeable. If it is, 
+        # if none of the other match, check if the buffer is writeable. If it is,
         # assume it's a file and continue.
         large_image = 'none'
 
@@ -107,7 +110,7 @@ def update_presence():
         large_text = 'Nothing'
         details = 'Nothing'
 
-    # Update the activity 
+    # Update the activity
     activity['assets']['large_image'] = large_image
     activity['assets']['large_text'] = large_text
     activity['details'] = details
@@ -129,8 +132,14 @@ def reconnect():
     if rpc_obj.reconnect():
         update_presence()
 
+def disconnect():
+    try:
+        if rpc_obj.connected:
+            rpc_obj.close()
+    except:
+        pass
 def is_writeable():
-    """Returns whether the buffer is writeable or not 
+    """Returns whether the buffer is writeable or not
     :returns: string
     """
     return vim.eval('&modifiable')
@@ -148,8 +157,8 @@ def get_filetype():
     return vim.eval('&filetype')
 def get_extension():
     """Get the extension for the file that is being edited.
-    Currently serves as a fallback if the filetype is null, which can 
-    happen if the filetype is unrecognized and/or unsupported by 
+    Currently serves as a fallback if the filetype is null, which can
+    happen if the filetype is unrecognized and/or unsupported by
     Vim (this is usually only the case when there are no plugins
     or anything else that adds a filetype to an unrecognized extension)
     :returns: string


### PR DESCRIPTION
To make a long story short, I needed to switch to Flatpak Discord in order to free up libc++ so I could install libc++-9-dev. Unfortunately, Flatpak's sandboxing forces Discord to expose its socket in a slightly different location. That's the primary intent of this PR: adding support for Flatpak Discord. This should also make it easy to add support for Snapcraft Discord, if Snap forces Discord to expose its socket in a slightly more exotic place. From my local testing, this change should have no impact on current installs. Flatpak support is disabled by default and has to be enabled with a variable. Works fine locally anyway (read: without an explicit symlink, it fails to connect, which means it tries to connect to the normal socket endpoint, which the .deb and .tar.* uses by default. The paths have been verified with logging while testing this PR)

I also added `:DiscordDisconnect`, which does exactly what the name says - it disconnects from the socket. As a bonus to this, I added a boolean that keeps track of whether the socket is open. It's extremely brute and I'm not sure if it works with all the edge cases, but it should at least reduce some CPU cycles if Discord's socket is dead for whatever reason. Works locally anyway :woman_shrugging: 

Aside that, there was a bug with the function trying to reconnect. It didn't return a type, which means it returns None, none is false, ergo it didn't reconnect. https://github.com/hugolgst/vimsence/blob/7b390c0ecf65e4bbc9b7335042891c874778cf25/python/vimsence.py#L129 requires a return value from https://github.com/hugolgst/vimsence/blob/7b390c0ecf65e4bbc9b7335042891c874778cf25/python/rpc.py#L99-L112, which it didn't previously have.

UpdatePresence is now DiscordUpdatePresence for namespacing and consistency purposes. UpdatePresence has been deprecated instead of removed to avoid disruption. 

I cleaned up the documentation a bit, and added a few more tags for searchability. (the tags file has also been regenerated).

One thing I haven't addressed by would like to address at some point: the use of VimSence vs Vimsence in the tags and text are inconsistent. Only one should really be used.