### PR TITLE
Make the plugin async

### DIFF
--- a/plugin/vimsence.vim
+++ b/plugin/vimsence.vim
@@ -26,26 +26,36 @@ sys.path.insert(0, python_root_dir)
 import vimsence
 EOF
 
-function! DiscordUpdatePresence()
+let s:vimsence_has_timers=has("timers")
+
+function! DiscordAsyncWrapper(callback)
+    if s:vimsence_has_timers
+        call timer_start(100, a:callback)
+    else
+        call a:callback(0)
+    endif
+endfunction
+
+function! DiscordUpdatePresence(tid)
     python3 vimsence.update_presence()
 endfunction
 
-function! DiscordReconnect()
+function! DiscordReconnect(tid)
     python3 vimsence.reconnect()
 endfunction
 
-function! DiscordDisconnect()
+function! DiscordDisconnect(tid)
     python3 vimsence.disconnect()
 endfunction
 
 command! -nargs=0 UpdatePresence echo "This command has been deprecated. Use :DiscordUpdatePresence instead."
-command! -nargs=0 DiscordUpdatePresence call DiscordUpdatePresence()
-command! -nargs=0 DiscordReconnect call DiscordReconnect()
-command! -nargs=0 DiscordDisconnect call DiscordDisconnect()
+command! -nargs=0 DiscordUpdatePresence call DiscordAsyncWrapper(function('DiscordUpdatePresence'))
+command! -nargs=0 DiscordReconnect call DiscordAsyncWrapper(function('DiscordReconnect'))
+command! -nargs=0 DiscordDisconnect call DiscordAsyncWrapper(function('DiscordDisconnect'))
 
 augroup DiscordPresence
     autocmd!
-    autocmd BufNewFile,BufRead,BufEnter * :call DiscordUpdatePresence()
+    autocmd BufNewFile,BufRead,BufEnter * :call DiscordAsyncWrapper(function('DiscordUpdatePresence'))
 augroup END
 
 let g:vimsence_loaded = 1

--- a/plugin/vimsence.vim
+++ b/plugin/vimsence.vim
@@ -57,14 +57,17 @@ endfunction
 " passed to timer callbacks.
 function! DiscordUpdatePresence(tid)
     python3 vimsence.update_presence()
+    let s:timer = -1
 endfunction
 
 function! DiscordReconnect(tid)
     python3 vimsence.reconnect()
+    let s:timer = -1
 endfunction
 
 function! DiscordDisconnect(tid)
     python3 vimsence.disconnect()
+    let s:timer = -1
 endfunction
 
 command! -nargs=0 UpdatePresence echo "This command has been deprecated. Use :DiscordUpdatePresence instead."

--- a/python/rpc.py
+++ b/python/rpc.py
@@ -194,6 +194,7 @@ class UnixDiscordIpcClient(DiscordIpcClient):
 
     def _connect(self):
         self._sock = socket.socket(socket.AF_UNIX)
+        self._sock.settimeout(1)
         pipe_pattern = self._get_pipe_pattern()
         flatpak_support = vim.eval('g:vimsence_discord_flatpak')
         position = ""


### PR DESCRIPTION
This should close (random words to prevent GH from auto-closing if merged) #9 

Fixes:

1. Timeout on UNIX is now 1s. See: https://docs.python.org/3/library/socket.html#socket.socket.settimeout 
     `setblocking` could also be an option, but that broke the plugin for me. `settimeout` seems to be the best option. Again, this only affects UNIX, because Windows just uses regular files. I don't think it's as big a problem there as a result?
2. Timers have been implemented for async behavior (... assuming I've understood everything correctly). This requires some version of Vim 8 to work. (requires +timers)

This should be tested properly before merging (preferably by the people who engaged in #9, because I can't easily reproduce that issue). 

