### PR TITLE
Add support for tsx and jsx

### DIFF
--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -46,7 +46,9 @@ remap = {
         "rust": "rs", 
         "typescript": "ts",
         "javascript": "js",
-        "snippets": "vim"
+        "snippets": "vim",
+        "typescriptreact": "ts",
+        "javascriptreact": "js",
 }
 
 file_explorers = [


### PR DESCRIPTION
Fixes #21. Now the `typescriptreact` and `javascriptreact` filetypes are recognised and map to `ts` and `js`.