### PR TITLE
Fix client id configuration variable

### DIFF
--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -29,8 +29,8 @@ base_activity = {
 
 client_id = '439476230543245312'
 # Get the application id from vim configuration if there is one
-if (vim.eval("exists('{}')".format("g:vimsence_app_id")) == "1"):
-    client_id = vim.eval("g:vimsence_app_id")
+if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
+    client_id = vim.eval("g:vimsence_client_id")
 
 # Contains which files has thumbnails.
 has_thumbnail = [


### PR DESCRIPTION
Use `vimsence_client_id` instead of `vimsence_app_id` to be consistent with `README.md`