### PR TITLE
Configuring custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone https://github.com/hugolgst/vimsence.git
 git submodule add https://github.com/hugolgst/vimsence.git vimsence
 ```
 
-## Configurate
+## Configuration
 You can configure the messages of VimSence in your `.vimrc` with these options:
 ```vim
 let g:vimsence_client_id = '439476230543245312'
@@ -51,6 +51,8 @@ let g:vimsence_editing_details = 'Editing: {}'
 let g:vimsence_editing_state = 'Working on: {}'
 let g:vimsence_file_explorer_text = 'In NERDTree'
 let g:vimsence_file_explorer_details = 'Looking for files'
+let g:vimsence_thumbnails = ['md']
+let g:vimence_remapping = {'markdown': 'md'}
 ```
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ let g:vimsence_editing_details = 'Editing: {}'
 let g:vimsence_editing_state = 'Working on: {}'
 let g:vimsence_file_explorer_text = 'In NERDTree'
 let g:vimsence_file_explorer_details = 'Looking for files'
-let g:vimsence_thumbnails = ['md']
-let g:vimence_remapping = {'markdown': 'md'}
+let g:vimsence_thumbnails = ['hs']
+let g:vimsence_remapping = {'haskell': 'hs'}
 ```
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ let g:vimsence_editing_details = 'Editing: {}'
 let g:vimsence_editing_state = 'Working on: {}'
 let g:vimsence_file_explorer_text = 'In NERDTree'
 let g:vimsence_file_explorer_details = 'Looking for files'
-let g:vimsence_thumbnails = ['hs']
-let g:vimsence_remapping = {'haskell': 'hs'}
+let g:vimsence_custom_icons = {'filetype': 'iconname'}
 ```
 
 ## Authors

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -33,14 +33,14 @@ if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
     client_id = vim.eval("g:vimsence_client_id")
 
 # Contains which files has thumbnails.
-has_thumbnail = [
+has_thumbnail = {
     'c', 'cr', 'hs', 'json', 'nim', 'ruby', 'cpp', 'go', 'javascript', 'markdown',
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'paco', 'tex', 'sh',
     'elixir', 'cs'
-]
+}
 
 if vim.eval("exists('g:vimsence_thumbnails')") == "1":
-    has_thumbnail.extend(vim.eval("g:vimsence_thumbnails"))
+    has_thumbnail.update(vim.eval("g:vimsence_thumbnails"))
 
 # Remaps file types to specific icons.
 # The key is the filetype, the value is the image name.

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -39,9 +39,6 @@ has_thumbnail = {
     'elixir', 'cs'
 }
 
-if vim.eval("exists('g:vimsence_thumbnails')") == "1":
-    has_thumbnail.update(vim.eval("g:vimsence_thumbnails"))
-
 # Remaps file types to specific icons.
 # The key is the filetype, the value is the image name.
 # This is mainly used where the file type itself doesn't
@@ -62,8 +59,14 @@ remap = {
         "javascriptreact": "js",
 }
 
-if vim.eval("exists('g:vimsence_remapping')") == "1":
-    remap.update(vim.eval("g:vimsence_remapping"))
+# Support for custom clients with icons
+# vimsence_custom_icons is a mapping with the file types
+# as the keys and their remapping which is the actual
+# name of the thumbnail as the values.
+if vim.eval("exists('g:vimsence_custom_icons')") == "1":
+    thumbnails = vim.eval("g:vimsence_custom_icons")
+    has_thumbnail.update(thumbnails.values())
+    remap.update(thumbnails)
 
 file_explorers = [
     "nerdtree", "vimfiler", "netrw"

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -39,6 +39,9 @@ has_thumbnail = [
     'elixir', 'cs'
 ]
 
+if vim.eval("exists('g:vimsence_thumbnails')") == "1":
+    has_thumbnail.extend(vim.eval("g:vimsence_thumbnails"))
+
 # Remaps file types to specific icons.
 # The key is the filetype, the value is the image name.
 # This is mainly used where the file type itself doesn't
@@ -58,6 +61,9 @@ remap = {
         "typescriptreact": "ts",
         "javascriptreact": "js",
 }
+
+if vim.eval("exists('g:vimsence_remapping')") == "1":
+    remap.update(vim.eval("g:vimsence_remapping"))
 
 file_explorers = [
     "nerdtree", "vimfiler", "netrw"


### PR DESCRIPTION
This adds the ability to declare which languages have custom thumbnails through `g:vimsence_custom_icons`. This is particularly useful in conjunction with a user-provided `g:vimsence_client_id`.

![rich-presence](https://user-images.githubusercontent.com/66708316/91662451-1822dd00-eb15-11ea-8108-3fb09cc0ee1a.png)

```vim
let g:vimsence_custom_icons = {'haskell': 'hs'}
```