### PR TITLE
Fortran, React and Sql support

### DIFF
--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -36,7 +36,7 @@ if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
 has_thumbnail = {
     'c', 'cr', 'hs', 'json', 'nim', 'ruby', 'cpp', 'go', 'javascript', 'markdown',
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'paco', 'tex', 'sh',
-    'elixir', 'cs'
+    'elixir', 'cs', 'f'
 }
 
 # Remaps file types to specific icons.
@@ -57,6 +57,7 @@ remap = {
         "snippets": "vim",
         "typescriptreact": "ts",
         "javascriptreact": "js",
+        "fortran": "f",
 }
 
 # Support for custom clients with icons
@@ -97,7 +98,7 @@ def update_presence():
 
     if rpc_obj is None or not rpc_obj.connected:
         # If we're flagged as disconnected, skip all this processing and save some CPU cycles.
-        return;
+        return
     global ignored_file_types
     global ignored_directories
     if (ignored_file_types == -1):
@@ -125,7 +126,7 @@ def update_presence():
     editing_text = 'Editing a {} file'
     if (vim.eval("exists('{}')".format("g:vimsence_editing_large_text")) == "1"):
         editing_text = vim.eval("g:vimsence_editing_large_text")
- 
+
     editing_state = 'Workspace: {}'
     if (vim.eval("exists('{}')".format("g:vimsence_editing_state")) == "1"):
         editing_state = vim.eval("g:vimsence_editing_state")
@@ -178,13 +179,13 @@ def update_presence():
 
     try:
         rpc_obj.set_activity(activity)
-    except BrokenPipeError as e:
+    except BrokenPipeError:
         # Connection to Discord is lost
         pass
-    except NameError as e:
+    except NameError:
         # Discord is not running
         pass
-    except OSError as e:
+    except OSError:
         # IO-related issues (possibly disconnected)
         pass
 
@@ -241,7 +242,7 @@ def get_extension():
     :returns: string
     """
 
-    return vim.eval('expand("%:e")');
+    return vim.eval('expand("%:e")')
 
 def get_directory():
 

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -36,7 +36,7 @@ if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
 has_thumbnail = {
     'c', 'cr', 'hs', 'json', 'nim', 'ruby', 'cpp', 'go', 'javascript', 'markdown',
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'paco', 'tex', 'sh',
-    'elixir', 'cs', 'f', 'react', 'sql', 'plsql'
+    'elixir', 'cs', 'f', 'jsx', 'tsx', 'sql', 'plsql'
 }
 
 # Remaps file types to specific icons.
@@ -55,8 +55,8 @@ remap = {
         "typescript": "ts",
         "javascript": "js",
         "snippets": "vim",
-        "typescriptreact": "react",
-        "javascriptreact": "react",
+        "typescriptreact": "tsx",
+        "javascriptreact": "jsx",
         "fortran": "f",
 }
 

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -36,7 +36,7 @@ if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
 has_thumbnail = {
     'c', 'cr', 'hs', 'json', 'nim', 'ruby', 'cpp', 'go', 'javascript', 'markdown',
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'paco', 'tex', 'sh',
-    'elixir', 'cs', 'f'
+    'elixir', 'cs', 'f', 'react'
 }
 
 # Remaps file types to specific icons.
@@ -55,8 +55,8 @@ remap = {
         "typescript": "ts",
         "javascript": "js",
         "snippets": "vim",
-        "typescriptreact": "ts",
-        "javascriptreact": "js",
+        "typescriptreact": "react",
+        "javascriptreact": "react",
         "fortran": "f",
 }
 

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -36,7 +36,7 @@ if (vim.eval("exists('{}')".format("g:vimsence_client_id")) == "1"):
 has_thumbnail = {
     'c', 'cr', 'hs', 'json', 'nim', 'ruby', 'cpp', 'go', 'javascript', 'markdown',
     'typescript', 'python', 'vim', 'rust', 'css', 'html', 'vue', 'paco', 'tex', 'sh',
-    'elixir', 'cs', 'f', 'react'
+    'elixir', 'cs', 'f', 'react', 'sql', 'plsql'
 }
 
 # Remaps file types to specific icons.


### PR DESCRIPTION
I gave up on C header files (since vim thinks they're cpp I'd say it should be fixed there) and brainfuck (becauise it has no logo...)

### Icons!

React (both for jsx and tsx):
 - https://cdn.idevie.com/wp-content/uploads/2015/12/React.js_logo.svg_.png

Fortran (so many file extensions...):
 - https://fortran-lang.org/assets/img/fortran_logo_256x256.png

SQL! I'll let you decide:
 - https://blog.composable.ai/wp-content/uploads/2017/02/sql-logo.png
 - https://w7.pngwing.com/pngs/28/601/png-transparent-sql-logo-illustration-microsoft-azure-sql-database-microsoft-sql-server-database-blue-text-logo.png

PL/SQL, for Oracle databases:
 - Use the same as sql
 - Use the same as sql but red
 - http://www.tutego.de/images/seminare/logos/oracle.png
 - https://pic.cr173.com/up/2016-1/201611412346.png

Closes #33 